### PR TITLE
Install ttrss from tar instead of git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM ubuntu
 MAINTAINER Christian Lück <christian@lueck.tv>
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
-  nginx git supervisor php5-fpm php5-cli php5-curl php5-gd php5-json \
-  php5-pgsql php5-mysql && apt-get clean
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        nginx supervisor php5-fpm php5-cli php5-curl php5-gd php5-json \
+        php5-pgsql php5-mysql \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # add ttrss as the only nginx site
 ADD ttrss.nginx.conf /etc/nginx/sites-available/ttrss
@@ -11,11 +13,15 @@ RUN ln -s /etc/nginx/sites-available/ttrss /etc/nginx/sites-enabled/ttrss
 RUN rm /etc/nginx/sites-enabled/default
 
 # install ttrss and patch configuration
-RUN git clone https://github.com/gothfox/Tiny-Tiny-RSS.git /var/www
+RUN mkdir /var/www \
+    && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl --no-install-recommends && rm -rf /var/lib/apt/lists/* \
+    && curl -SL https://github.com/gothfox/Tiny-Tiny-RSS/archive/master.tar.gz | tar xvz -C /var/www --strip-components 1 \
+    && apt-get purge -y --auto-remove curl \
+    && chown www-data:www-data -R /var/www
+
 WORKDIR /var/www
 RUN cp config.php-dist config.php
 RUN sed -i -e "/'SELF_URL_PATH'/s/ '.*'/ 'http:\/\/localhost\/'/" config.php
-RUN chown www-data:www-data -R /var/www
 
 # expose only nginx HTTP port
 EXPOSE 80


### PR DESCRIPTION
Installing git just to retreive some files is overkill and increases the size of the final image quite a bit. This change removes git from the install and pulls the tar file from github in order to install ttrss. It also strives to keep the resulting image as small as possible.

side note: I think that the docker image should be tagged in relation to the released versions of ttrss (eg 1.14, 1.15, etc). In that case instead of pulling  from 
`https://github.com/gothfox/Tiny-Tiny-RSS/archive/master.tar.gz` 
you could set something up like

```
ENV TTRSS_VERSION 1.15
https://github.com/gothfox/Tiny-Tiny-RSS/archive/$TTRSS_VERSION.tar.gz
```
