### PR TITLE
Install php5-mcrypt as well.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,9 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
   nginx git supervisor php5-fpm php5-cli php5-curl php5-gd php5-json \
   php5-pgsql php5-mysql php5-mcrypt && apt-get clean
 
+# enable the mcrypt module
+RUN php5enmod mcrypt
+
 # add ttrss as the only nginx site
 ADD ttrss.nginx.conf /etc/nginx/sites-available/ttrss
 RUN ln -s /etc/nginx/sites-available/ttrss /etc/nginx/sites-enabled/ttrss

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Christian Lück <christian@lueck.tv>
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
   nginx git supervisor php5-fpm php5-cli php5-curl php5-gd php5-json \
-  php5-pgsql php5-mysql && apt-get clean
+  php5-pgsql php5-mysql php5-mcrypt && apt-get clean
 
 # add ttrss as the only nginx site
 ADD ttrss.nginx.conf /etc/nginx/sites-available/ttrss


### PR DESCRIPTION
Installing php5-mcrypt seems to be required:

4 docker exec ttrss_main tail -n1 /tmp/ttrss-update-daemon.stderr
PHP Fatal error:  Call to undefined function mcrypt_decrypt() in /var/www/include/crypt.php on line 12