### PR TITLE
Imp: adapt NGinx configuration file if TinyTinyRss is not locate in web site root, based on SELF_URL_PATH.

### DIFF
--- a/build-ttrssImage.sh
+++ b/build-ttrssImage.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker build --rm -t toony/ttrss .


### PR DESCRIPTION
Used to get ttrss available from URLs like: http://www.domain.tld/tt-rss
Works behind reverse proxy too.
