### PR TITLE
Make builds with newest Ubuntu work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,16 +2,19 @@ FROM ubuntu
 MAINTAINER Christian Lück <christian@lueck.tv>
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
-  nginx supervisor php5-fpm php5-cli php5-curl php5-gd php5-json \
-  php5-pgsql php5-mysql php5-mcrypt && apt-get clean && rm -rf /var/lib/apt/lists/*
+  nginx supervisor php-fpm php-cli php-curl php-gd php-json \
+  php-pgsql php-mysql php-mcrypt && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # enable the mcrypt module
-RUN php5enmod mcrypt
+RUN phpenmod mcrypt
 
 # add ttrss as the only nginx site
 ADD ttrss.nginx.conf /etc/nginx/sites-available/ttrss
 RUN ln -s /etc/nginx/sites-available/ttrss /etc/nginx/sites-enabled/ttrss
 RUN rm /etc/nginx/sites-enabled/default
+
+# php-fpm fails without this
+RUN mkdir -p /run/php/
 
 # install ttrss and patch configuration
 WORKDIR /var/www

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:xenial
 MAINTAINER Christian Lück <christian@lueck.tv>
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,8 +1,8 @@
 [supervisord]
 nodaemon=true
 
-[program:php5-fpm]
-command=/usr/sbin/php5-fpm --nodaemonize
+[program:php-fpm]
+command=/usr/sbin/php-fpm7.0 --nodaemonize
 
 [program:nginx]
 command=/usr/sbin/nginx -g "daemon off;"

--- a/ttrss.nginx.conf
+++ b/ttrss.nginx.conf
@@ -10,7 +10,7 @@ server {
 
 	location ~ \.php$ {
 		fastcgi_split_path_info ^(.+\.php)(/.+)$;
-		fastcgi_pass unix:/var/run/php5-fpm.sock;
+		fastcgi_pass unix:/run/php/php7.0-fpm.sock;
 		fastcgi_index index.php;
 		include fastcgi_params;
 	}


### PR DESCRIPTION
This should fix builds with newer Ubuntu (#27).

I find it quite sad that these kind of changes are needed with a new distro version, but well... Ubuntu.
