### PR TITLE
Add support for the newer Ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,13 @@ FROM ubuntu
 MAINTAINER Christian Lück <christian@lueck.tv>
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
-  nginx supervisor php5-fpm php5-cli php5-curl php5-gd php5-json \
-  php5-pgsql php5-mysql php5-mcrypt && apt-get clean && rm -rf /var/lib/apt/lists/*
+  nginx supervisor php-fpm php-cli php-curl php-gd php-json \
+  php-pgsql php-mysql php-mcrypt php-mbstring php-xml && apt-get clean && rm -rf /var/lib/apt/lists/* && \
+  phpenmod mcrypt && mkdir /run/php
 
 # enable the mcrypt module
-RUN php5enmod mcrypt
+RUN phpenmod mcrypt
+
 
 # add ttrss as the only nginx site
 ADD ttrss.nginx.conf /etc/nginx/sites-available/ttrss

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,22 +6,19 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get update && apt-get install -y \
   php-pgsql php-mysql php-mcrypt php-mbstring php-xml && apt-get clean && rm -rf /var/lib/apt/lists/* && \
   phpenmod mcrypt && mkdir /run/php
 
-# enable the mcrypt module
-RUN phpenmod mcrypt
-
 
 # add ttrss as the only nginx site
 ADD ttrss.nginx.conf /etc/nginx/sites-available/ttrss
-RUN ln -s /etc/nginx/sites-available/ttrss /etc/nginx/sites-enabled/ttrss
-RUN rm /etc/nginx/sites-enabled/default
+RUN ln -s /etc/nginx/sites-available/ttrss /etc/nginx/sites-enabled/ttrss \
+    && rm /etc/nginx/sites-enabled/default
 
 # install ttrss and patch configuration
 WORKDIR /var/www
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl --no-install-recommends && rm -rf /var/lib/apt/lists/* \
     && curl -SL https://tt-rss.org/gitlab/fox/tt-rss/repository/archive.tar.gz?ref=master | tar xzC /var/www --strip-components 1 \
     && apt-get purge -y --auto-remove curl \
-    && chown www-data:www-data -R /var/www
-RUN cp config.php-dist config.php
+    && chown www-data:www-data -R /var/www \
+    && cp config.php-dist config.php
 
 # expose only nginx HTTP port
 EXPOSE 80

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -2,7 +2,7 @@
 nodaemon=true
 
 [program:php5-fpm]
-command=/usr/sbin/php5-fpm --nodaemonize
+command=/usr/sbin/php-fpm7.0 --nodaemonize
 
 [program:nginx]
 command=/usr/sbin/nginx -g "daemon off;"

--- a/ttrss.nginx.conf
+++ b/ttrss.nginx.conf
@@ -10,9 +10,10 @@ server {
 
 	location ~ \.php$ {
 		fastcgi_split_path_info ^(.+\.php)(/.+)$;
-		fastcgi_pass unix:/var/run/php5-fpm.sock;
+		fastcgi_pass unix:/run/php/php7.0-fpm.sock;
 		fastcgi_index index.php;
 		include fastcgi_params;
+		fastcgi_param SCRIPT_FILENAME $document_root/$fastcgi_script_name;
 	}
 }
 


### PR DESCRIPTION
In the recent Ubuntu version php5 is not available anymore. This PR changes the following:
- update PHP to version 7
- update supervisor config accordingly
- update nginx config accordingly
- decrease amount of layers in the resulting image